### PR TITLE
Remove unused category taxonomy from config

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -60,5 +60,4 @@ menus:
       weight: 90
 
 taxonomies:
-  category: categories
   tag: tags


### PR DESCRIPTION
The category taxonomy is no longer used. Only tag taxonomy is active, so removing this reduces configuration complexity.