### PR TITLE
Publish: The Irony of AI Replacement Predictions and the Dunning-Kruger Effect

### DIFF
--- a/content/posts/the-irony-of-ai-replacement-predictions-and-the-dunning-kruger-effect.md
+++ b/content/posts/the-irony-of-ai-replacement-predictions-and-the-dunning-kruger-effect.md
@@ -1,0 +1,23 @@
+---
+title: The Irony of AI Replacement Predictions and the Dunning-Kruger Effect
+description: An analysis of the irony in mediocre thinkers predicting AI will replace cognitive work like their own, exploring how the Dunning-Kruger effect prevents accurate self-assessment and why those making the loudest predictions may be most vulnerable to displacement.
+tags:
+  - artificial-intelligence
+  - cognitive-bias
+  - dunning-kruger
+  - future-of-work
+date: 2026-02-13
+lastmod: 2026-02-09
+---
+
+Mediocre thinkers who overestimate their abilities now predict AI will eliminate work for people like themselves. The irony is sharp.
+
+The Dunning-Kruger effect. People with limited competence in a domain lack the awareness to recognize it. They can't judge their own capability because real judgment requires the skills they lack. So they assume they're exceptional—and from that height, they look at AI and conclude it will do what they believe they themselves are doing: something impressive, valuable, central to the economy.
+
+The deeper irony is structural. The same limitation that makes someone overestimate their thinking keeps them from seeing why their prediction is wrong. They're forecasting the obsolescence of mediocre cognition while demonstrating it. The prophecy and the prophet are made of the same material, and neither can notice the seam.
+
+We tend to project our own level of understanding onto the systems we're evaluating. If you genuinely produce shallow work—pattern-matched outputs dressed up with confident delivery—then AI does look like it's about to replace you, because current systems can already do what you do. But those who don't recognize their work as shallow will be the most surprised when the replacement arrives, because they never built an accurate model of what they were actually contributing.
+
+Predicting the end of work is intellectual performance—it signals you're thinking big, looking forward, seeing the future. It's not analysis; it's positioning.
+
+The real question is what survives AI augmentation. The answer isn't "exceptional minds" in some abstract sense. It's specific capabilities: formulating problems others haven't noticed, synthesizing across domains with unclear boundaries, deciding under genuine ambiguity where no training data yet exists. These are harder to spot and harder to fake than the confident delivery that now passes for expertise. The people best positioned for what's coming are, almost by definition, the least likely to prophesy loudly—because they already know how much they don't know.


### PR DESCRIPTION
Published from Obsidian

**File:** Published/The Irony of AI Replacement Predictions and the Dunning-Kruger Effect.md
**Images:** 0