### PR TITLE
fix: remove stale references to task commit, markdownlint, and Hugo version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,7 @@ jobs:
           submodules: true
       - uses: actions/configure-pages@v5
         id: pages
-      - uses: peaceiris/actions-hugo@v3
+      - uses: peaceiris/actions-hugo@v3 # unpinned: tracks latest like Homebrew
         with:
           extended: true
       - run: hugo --gc --minify

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -22,12 +22,7 @@
   },
   "files.associations": {
     "*.md": "markdown",
-    "CLAUDE.md": "markdown",
-    "CONTRIBUTING.md": "markdown",
-    "DEVELOPMENT.md": "markdown"
-  },
-  "markdownlint.config": {
-    "extends": ".markdownlint.json"
+    "CLAUDE.md": "markdown"
   },
   "search.exclude": {
     "**/public": true,

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Visit <http://localhost:1313> for local development.
 
 ## Technology Stack
 
-- **Static Site Generator**: [Hugo](https://gohugo.io/) v0.152.2
+- **Static Site Generator**: [Hugo](https://gohugo.io/) (Extended)
 - **Theme**: [hugo-coder](https://github.com/luizdepra/hugo-coder)
 - **Build Tool**: [Task](https://taskfile.dev)
 - **Hosting**: GitHub Pages
@@ -34,11 +34,10 @@ All development uses Task for command orchestration:
 
 - `task build` - Build the Hugo site
 - `task serve` - Start local development server with live reload
-- `task fix` - Auto-fix formatting with Prettier and markdownlint
+- `task fix` - Auto-fix formatting with Prettier
 - `task optimize-images` - Optimize images in static/images
 - `task update` - Update hugo-coder theme to latest version
 - `task bootstrap` - Install tools via Homebrew
-- `task commit` - Interactive commit workflow (non-main branches only)
 
 Run `task --list` to see all available tasks with descriptions.
 
@@ -64,7 +63,7 @@ Run `task --list` to see all available tasks with descriptions.
 1. Create a feature branch (never commit to `main`)
 2. Make your changes
 3. Run `task fix` to format code
-4. Use `task commit` for interactive commit workflow
+4. Commit your changes with a descriptive message
 5. Create a pull request
 
 ## Content Guidelines
@@ -78,7 +77,6 @@ Run `task --list` to see all available tasks with descriptions.
 ## Code Quality
 
 - **Formatting**: Prettier (prose wrap at 80 chars)
-- **Linting**: markdownlint
 - **CI**: GitHub Actions builds and deploys on push to main
 
 ## Deployment


### PR DESCRIPTION
## Summary

- Remove `task commit` references from README (command list and workflow steps)
- Remove markdownlint references from README and VSCode settings (not installed or configured)
- Replace hardcoded Hugo v0.152.2 with generic "(Extended)" since version is unpinned
- Remove phantom file associations for CONTRIBUTING.md and DEVELOPMENT.md from VSCode settings
- Document accepted risk of unpinned Hugo version in CI workflow

Cleans up documentation drift from tooling removal in 0c8d8f3.

## Test plan

- [x] `task build` passes
- [x] `bunx prettier --write` shows no formatting changes
- [x] No functional code changes — docs and config only

🤖 Generated with [Claude Code](https://claude.com/claude-code)