### PR TITLE
Add Claude Code hooks for auto-format and theme protection

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "command": "echo \"$CLAUDE_FILE_PATH\" | grep -q 'themes/' && echo 'BLOCK: Do not edit theme submodule files' && exit 1 || exit 0"
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "command": "prettier --write \"$CLAUDE_FILE_PATH\" 2>/dev/null || true"
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 .task/
 Brewfile.lock.json
-.claude/
 
 # Created by https://www.toptal.com/developers/gitignore/api/hugo
 # Edit at https://www.toptal.com/developers/gitignore?templates=hugo


### PR DESCRIPTION
## Summary

- Add PostToolUse hook that runs Prettier after every Edit/Write, eliminating the need to re-read files after reformatting
- Add PreToolUse hook that blocks edits to `themes/` directory, preventing accidental theme submodule modifications
- Track `.claude/settings.json` in the repo so hooks are shared

## Test plan

- [ ] Edit a markdown file and verify Prettier runs automatically
- [ ] Attempt to edit a file under `themes/` and verify it is blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)