### PR TITLE
fix: deduplicate icon and add theme_color in site.webmanifest

### DIFF
--- a/static/site.webmanifest
+++ b/static/site.webmanifest
@@ -6,7 +6,8 @@
     {
       "src": "/images/android-chrome-144x144.png",
       "sizes": "144x144",
-      "type": "image/png"
+      "type": "image/png",
+      "purpose": "any maskable"
     },
     {
       "src": "/images/android-chrome-192x192.png",
@@ -17,15 +18,10 @@
       "src": "/images/android-chrome-512x512.png",
       "sizes": "512x512",
       "type": "image/png"
-    },
-    {
-      "src": "/images/android-chrome-144x144.png",
-      "sizes": "144x144",
-      "type": "image/png",
-      "purpose": "maskable"
     }
   ],
   "background_color": "#ffffff",
+  "theme_color": "#ffffff",
   "display": "standalone",
   "start_url": "/",
   "scope": "/"


### PR DESCRIPTION
## Summary

- Merged duplicate 144x144 icon entries into single entry with `"purpose": "any maskable"`
- Added missing `theme_color`

Closes #597

## Test plan

- [ ] Verify site.webmanifest is valid JSON after deploy
- [ ] Check browser dev tools for manifest parsing errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)