### PR TITLE
fix: standardize prettier invocation to bunx

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,13 +3,25 @@
     "PreToolUse": [
       {
         "matcher": "Edit|Write",
-        "command": "echo \"$CLAUDE_FILE_PATH\" | grep -q 'themes/' && echo 'BLOCK: Do not edit theme submodule files' && exit 1 || exit 0"
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo \"$CLAUDE_FILE_PATH\" | grep -q 'themes/' && echo 'BLOCK: Do not edit theme submodule files' && exit 1 || exit 0",
+            "timeout": 5
+          }
+        ]
       }
     ],
     "PostToolUse": [
       {
         "matcher": "Edit|Write",
-        "command": "prettier --write \"$CLAUDE_FILE_PATH\" 2>/dev/null || true"
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bunx prettier --write \"$CLAUDE_FILE_PATH\" 2>/dev/null || true",
+            "timeout": 10
+          }
+        ]
       }
     ]
   }

--- a/Brewfile
+++ b/Brewfile
@@ -1,6 +1,7 @@
+tap "oven-sh/bun"
+brew "bun"
 brew "gh"
 brew "go-task"
 brew "hugo"
 brew "imagemagick"
 brew "pngquant"
-brew "prettier"

--- a/taskfile.yml
+++ b/taskfile.yml
@@ -29,7 +29,7 @@ tasks:
     desc: Auto-fix formatting with Prettier
     deps: [bootstrap]
     cmds:
-      - prettier --write --list-different --ignore-unknown .
+      - bunx prettier --write --list-different --ignore-unknown .
 
   build:
     desc: Build Hugo site including drafts and future posts


### PR DESCRIPTION
## Summary

- Replaced direct `prettier` with `bunx prettier` in taskfile.yml and Claude hooks
- Removed `prettier` from Brewfile, added `bun` (via `oven-sh/bun` tap) instead
- Retained `bootstrap` dep on `fix` task for bun availability

Closes #601

## Test plan

- [ ] `task bootstrap` installs bun
- [ ] `task fix` runs prettier via bunx
- [ ] Claude Code PostToolUse hook formats files after edits

🤖 Generated with [Claude Code](https://claude.com/claude-code)