### PR TITLE
fix: remove unnecessary defaults from deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,7 @@
 name: deploy
 
 on:
-  workflow_dispatch: null
+  workflow_dispatch:
   push:
     branches: [main]
   schedule:
@@ -14,11 +14,6 @@ permissions:
 
 concurrency:
   group: pages
-  cancel-in-progress: false
-
-defaults:
-  run:
-    shell: bash
 
 jobs:
   build:


### PR DESCRIPTION
## Summary

- Removed `cancel-in-progress: false` (already the default)
- Removed `defaults.run.shell: bash` (default on ubuntu-latest)
- Changed `workflow_dispatch: null` to idiomatic empty mapping

Closes #599

## Test plan

- [ ] Workflow triggers correctly on push, dispatch, and schedule

🤖 Generated with [Claude Code](https://claude.com/claude-code)