### PR TITLE
fix: clarify intentional taxonomy override in hugo.yaml

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -59,5 +59,5 @@ menus:
       url: "posts/"
       weight: 90
 
-taxonomies:
+taxonomies: # override default to exclude categories
   tag: tags


### PR DESCRIPTION
## Summary

- Added comment explaining that the explicit `taxonomies` block intentionally suppresses Hugo's default `category` taxonomy

Closes #598

## Test plan

- [ ] `task build` produces same page count with no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)