### PR TITLE
fix: remove Go rule from .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,6 +14,3 @@ max_line_length = off
 [*.{yaml,yml}]
 indent_style = space
 indent_size = 2
-
-[*.go]
-indent_style = tab


### PR DESCRIPTION
## Summary

- Removed `[*.go]` section — no Go files in this repo

Closes #602

## Test plan

- [ ] No Go files exist in repo to be affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)