### PR TITLE
fix: load EB Garamond via link tag instead of render-blocking SCSS import

### DIFF
--- a/assets/scss/custom-fonts.scss
+++ b/assets/scss/custom-fonts.scss
@@ -1,10 +1,7 @@
 // Custom font overrides for philoserf/site
 // Override theme font variables to prioritize Inter and Menlo
 
-// Import EB Garamond for the params.info motto
-@import url('https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400..800;1,400..800&display=swap');
-
-// Inter is loaded via <link> in layouts/partials/head/extensions.html
+// Both fonts loaded via <link> in layouts/partials/head/extensions.html
 $font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", Helvetica, sans-serif;
 $code-font-family: "Menlo", "Monaco", "Consolas", "Liberation Mono", "SFMono-Regular", monospace;
 

--- a/layouts/partials/head/extensions.html
+++ b/layouts/partials/head/extensions.html
@@ -1,4 +1,4 @@
-<!-- Load Inter font from Google Fonts -->
+<!-- Load fonts from Google Fonts -->
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400..800;1,400..800&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">


### PR DESCRIPTION
## Summary

- Moved EB Garamond from `@import` in SCSS to `<link>` in extensions.html
- Combined both fonts into a single Google Fonts request
- Eliminates render-blocking font load

Closes #595

## Test plan

- [ ] EB Garamond still renders on motto and latin-motto elements
- [ ] No render-blocking warnings in browser dev tools for fonts

🤖 Generated with [Claude Code](https://claude.com/claude-code)