### PR TITLE
feat: add rel=me to Mastodon and remove Bluesky

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -33,9 +33,7 @@ params:
     - name: Mastodon
       icon: "fa-brands fa-mastodon"
       url: https://pkm.social/@philoserf
-    - name: Bluesky
-      icon: "fa-brands fa-bluesky"
-      url: https://philoserf.bsky.social
+      rel: me
   customSCSS:
     - scss/custom-fonts.scss
 


### PR DESCRIPTION
## Summary

- Added `rel: me` to Mastodon social link for fediverse identity verification
- Removed Bluesky social link

Closes #617

## Test plan

- [ ] Mastodon link renders with `rel="me"` attribute
- [ ] Bluesky link no longer appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)