### PR TITLE
feat: add fediverseCreator param for fediverse attribution

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -26,6 +26,7 @@ params:
     intellectual essays
   avatarURL: /images/avatar.jpeg
   colorScheme: auto
+  fediverseCreator: "@philoserf@pkm.social"
   social:
     - name: GitHub
       icon: "fa-brands fa-github"


### PR DESCRIPTION
## Summary

- Added `fediverseCreator: "@philoserf@pkm.social"` to hugo.yaml for `fediverse:creator` meta tag

Closes #618

## Test plan

- [ ] Page source contains `<meta name="fediverse:creator" content="@philoserf@pkm.social" />`

🤖 Generated with [Claude Code](https://claude.com/claude-code)