### PR TITLE
feat: enable series taxonomy for grouping related essays

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -60,3 +60,4 @@ menus:
 
 taxonomies: # override default to exclude categories
   tag: tags
+  series: series


### PR DESCRIPTION
## Summary

- Added `series: series` to taxonomies in hugo.yaml
- Posts with `series: ["Series Name"]` in frontmatter will get automatic "See also in" cross-links

Closes #621

## Test plan

- [ ] `task build` succeeds with no warnings
- [ ] `/series/` page renders after adding series frontmatter to posts

🤖 Generated with [Claude Code](https://claude.com/claude-code)