### PR TITLE
fix: drop missing SVG favicon references via partial override

### DIFF
--- a/layouts/_partials/head/custom-icons.html
+++ b/layouts/_partials/head/custom-icons.html
@@ -1,0 +1,7 @@
+<link rel="icon" type="image/png" href="{{ .Site.Params.favicon_32 | default "/images/favicon-32x32.png" | relURL }}" sizes="32x32">
+<link rel="icon" type="image/png" href="{{ .Site.Params.favicon_16 | default "/images/favicon-16x16.png" | relURL }}" sizes="16x16">
+
+<link rel="apple-touch-icon" href="{{ .Site.Params.touchicon | default "/images/apple-touch-icon.png" | relURL }}">
+<link rel="apple-touch-icon" sizes="180x180" href="{{ .Site.Params.touchicon | default "/images/apple-touch-icon.png" | relURL }}">
+
+<link rel="manifest" href="{{ .Site.Params.manifest | default "/site.webmanifest" | relURL }}">


### PR DESCRIPTION
## Summary

- Added local override of theme's `custom-icons.html` partial
- Removed references to `favicon.svg` and `safari-pinned-tab.svg` (files don't exist)
- Keeps PNG favicons, apple-touch-icon, and webmanifest references

Closes #625

## Test plan

- [ ] No broken `<link>` tags for SVG favicons in page source
- [ ] PNG favicons still load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)