### PR TITLE
fix: override series partial to handle string frontmatter values

### DIFF
--- a/layouts/_partials/posts/series.html
+++ b/layouts/_partials/posts/series.html
@@ -1,0 +1,34 @@
+{{ $currentPageUrl := .RelPermalink }}
+{{ if .Params.series }}
+{{- $seriesList := .Params.series -}}
+{{- if not (reflect.IsSlice $seriesList) -}}
+  {{- $seriesList = slice $seriesList -}}
+{{- end -}}
+<section class="see-also">
+  {{ range $seriesList }}
+    {{ $name := . | anchorize }}
+    {{ $series := index $.Site.Taxonomies.series $name }}
+    {{ if gt (len $series.Pages) 1 }}
+      <h3 id="{{ i18n "see_also" | default "See also in" | anchorize }}-{{ anchorize . | safeURL }}">
+        {{ i18n "see_also" | default "See also in" }} {{ . }}
+        <a class="heading-link" href="#{{ i18n "see_also" | default "See also in" | anchorize }}-{{ anchorize . | safeURL }}">
+          <i class="fa-solid fa-link" aria-hidden="true" title="{{ i18n "link_to_heading" | default "Link to heading" }}"></i>
+          <span class="sr-only">{{ i18n "link_to_heading" | default "Link to heading" }}</span>
+        </a>
+      </h3>
+      <nav>
+        <ul>
+        {{ $maxItems := $.Site.Params.maxSeeAlsoItems | default 5 }}
+        {{ range first (add $maxItems 1) $series.Pages }}
+          {{ if ne .RelPermalink $currentPageUrl }}
+            <li>
+              <a href="{{ .Params.externalLink | default .RelPermalink }}">{{ .Title }}</a>
+            </li>
+          {{ end }}
+        {{ end }}
+        </ul>
+      </nav>
+    {{ end }}
+  {{ end }}
+</section>
+{{ end }}


### PR DESCRIPTION
## Summary

- Override hugo-coder theme's `series.html` partial to handle both string and list values for `series` frontmatter
- Obsidian publishes `series: smegps` (string) but the theme's partial uses `range`, which requires a list
- The override wraps string values in a slice before iterating, fixing the build error

## Test plan

- [x] `task build` passes with 625 pages, zero warnings
- [ ] Verify series links render correctly on affected posts (e.g., be, eat, books-i-have-read)

🤖 Generated with [Claude Code](https://claude.com/claude-code)