### PR TITLE
Add curated Start Here page

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -8,4 +8,4 @@ On thinking and writing, poetry and story, AI and cognition, civilizational drif
 
 {{< latin-motto >}}
 
-Start with [About](about/), see what I'm focused on [Now](now/), or browse the [posts](posts/).
+New here? [Start here](start-here/). Or read [About](about/), see what I'm focused on [Now](now/), or browse the [posts](posts/).

--- a/content/_index.md
+++ b/content/_index.md
@@ -8,4 +8,4 @@ On thinking and writing, poetry and story, AI and cognition, civilizational drif
 
 {{< latin-motto >}}
 
-New here? [Start here](start-here/). Or read [About](about/), see what I'm focused on [Now](now/), or browse the [posts](posts/).
+New here? [Start here]({{< ref "/start-here" >}}). Or read [About]({{< ref "/about" >}}), see what I'm focused on [Now]({{< ref "/now" >}}), or browse the [posts]({{< ref "/posts" >}}).

--- a/content/start-here.md
+++ b/content/start-here.md
@@ -1,0 +1,43 @@
+---
+title: Start Here
+description: "A curated way into the archive — fourteen essays grouped by theme, for readers who don't want to start at the newest post and scroll."
+lastmod: 2026-06-04
+---
+
+There are more than a hundred essays here, newest-first at [Posts](/posts/). That's a hard place to begin. So here's a shorter way in: a handful per theme, each with a line on why I'd point you to it.
+
+## Thinking & writing
+
+- [The Two Epistemic Cycles]({{< ref "/posts/two-epistemic-cycles" >}}) — the two Latin mottos behind this whole project: think, learn, connect, declare; then perceive, connect, effect.
+- [Uncompressed Public Thinking]({{< ref "/posts/uncompressed-public-thinking" >}}) — why I think out loud at all, and what we lost when public thought got optimized.
+- [Montaigne's Essay Method]({{< ref "/posts/montaignes-essay-method" >}}) — the method most of these essays follow: self as instrument, inquiry as the destination.
+
+## AI & cognition
+
+- [Intent-First Development]({{< ref "/posts/intent-first-development" >}}) — the abstraction layer is moving from code to intent; we write what we mean and agents compile it.
+- [New Metaphors for AI and Cognition]({{< ref "/posts/new-metaphors-for-ai-and-cognition" >}}) — past amplification, toward co-regulation: exoskeletons and cognitive compilers.
+
+## Civilizational drift
+
+- [Civilizational Collapse and Knowledge Transfer]({{< ref "/posts/civilizational-collapse-and-knowledge-transfer" >}}) — civilizations matter less for surviving than for what they carry across the break.
+- [The Cassandra Inversion]({{< ref "/posts/cassandra-inversion" >}}) — when every voice is urgent, real warnings become indistinguishable from manufactured ones.
+
+## Identity & ethics
+
+- [Leaning Against Your Nature]({{< ref "/posts/leaning-against-your-nature" >}}) — self-knowledge matters as a prerequisite for counterpressure, not for going with the grain.
+- [Three Positions on Existence]({{< ref "/posts/three-positions-on-existence" >}}) — affirmation, negation, suspension, and what each one costs.
+
+## Poetry & story
+
+- [Bare Feet on Snow]({{< ref "/posts/bare-feet-on-snow" >}}) — a poem: four seasons of wordless communion between body and earth.
+- [Old Man by the River]({{< ref "/posts/old-man-by-the-river" >}}) — a short story about a father, a son, and a morning of fishing.
+- [Kalbeth of the Orbital Authority]({{< ref "/posts/kalbeth-of-the-orbital-authority" >}}) — Macbeth retold in an interplanetary empire, predictive AIs in place of the witches.
+
+## The small crafts of attention
+
+- [Chemex Brewing Guide]({{< ref "/posts/chemex-brewing-guide" >}}) — coffee, measured: pour timing and roast-specific adjustments for a clean cup.
+- [Mise en Place for Knowledge Workers]({{< ref "/posts/mise-en-place-practices-for-knowledge-workers" >}}) — kitchen discipline carried to the desk.
+
+---
+
+Or just go to [Posts](/posts/) and start with whatever title pulls at you.

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -30,6 +30,12 @@ params:
 
 menus:
   main:
+    - identifier: start-here
+      name: Start Here
+      pageRef: /start-here
+      weight: 5
+      params:
+        description: A curated way into the archive
     - identifier: about
       name: About
       pageRef: /about


### PR DESCRIPTION
## Summary
Adds a hand-curated **Start Here** page — a thematic doorway into the 110+ post archive. Newest-first at `/posts` is a hard place to begin; this gives newcomers 14 essays across the six themes the homepage already names, each with a one-line "why read this."

With taxonomies intentionally disabled in `hugo.yaml`, this is the site's only thematic navigation.

## Changes
- `content/start-here.md` — the page; internal links use `{{< ref >}}` so renames break the build instead of 404ing
- `hugo.yaml` — `Start Here` main-menu item at `weight: 5` (before About)
- `content/_index.md` — homepage now leads with "New here? Start here."

## Themes & picks
- **Thinking & writing** — Two Epistemic Cycles · Uncompressed Public Thinking · Montaigne's Essay Method
- **AI & cognition** — Intent-First Development · New Metaphors for AI and Cognition
- **Civilizational drift** — Civilizational Collapse and Knowledge Transfer · The Cassandra Inversion
- **Identity & ethics** — Leaning Against Your Nature · Three Positions on Existence
- **Poetry & story** — Bare Feet on Snow · Old Man by the River · Kalbeth of the Orbital Authority
- **Small crafts** — Chemex Brewing Guide · Mise en Place for Knowledge Workers

## Verification
`task check` (strict `--panicOnWarning` build) passes — all 14 refs resolve.