### PR TITLE
Remove blank lines from vCard template (fixes #715)

### DIFF
--- a/layouts/index.vcard.vcf
+++ b/layouts/index.vcard.vcf
@@ -8,17 +8,14 @@ N:{{ $c.familyName }};{{ $c.givenName }};;;
 NICKNAME:{{ .Site.Params.nickname }}
 BDAY:{{ $c.birthday }}
 LANG:{{ .Site.Language.Locale | default "en" }}
-
 EMAIL;TYPE=INTERNET:{{ .Site.Params.email }}
 TEL;TYPE=CELL:{{ $c.phone }}
 ADR;TYPE=HOME:;;{{ $a.street }};{{ $a.city }};{{ $a.region }};{{ $a.postalCode }};{{ $a.country }}
 TZ:{{ $c.timezone }}
-
 URL:{{ .Site.BaseURL }}
 X-SOCIALPROFILE;type=github:{{ $s.github }}
 X-SOCIALPROFILE;type=mastodon:{{ $s.mastodon }}
 X-SOCIALPROFILE;type=bluesky:{{ $s.bluesky }}
-
 PHOTO;VALUE=URI:{{ "apple-touch-icon.png" | absURL }}
 SOURCE:{{ "vcard.vcf" | absURL }}
 NOTE:{{ .Site.Params.motto }}


### PR DESCRIPTION
Fixes #715.

## Problem
`layouts/index.vcard.vcf` had three blank lines (after `LANG`, `TZ`, and the bluesky `X-SOCIALPROFILE`) that rendered straight into `vcard.vcf`. RFC 2426 §2.4.2 forbids empty content lines in a vCard 3.0 body; strict parsers and some iOS Contacts imports silently drop the properties that follow a blank line.

## Fix
Removed the three blank separators.

## Verification
Built the site and inspected the rendered `vcard.vcf`:
- 0 blank lines
- all 18 properties intact between `BEGIN:VCARD` and `END:VCARD`

`task check` (strict `--panicOnWarning`) passes.