### PR TITLE
Align site build flags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,4 +39,6 @@ jobs:
           hugo version
 
       - name: Build with Hugo
-        run: hugo --minify
+        run: hugo --gc --minify --panicOnWarning
+        env:
+          HUGO_ENV: production

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ There is no end-to-end test of the publish → render pipeline. The strict Hugo 
 Automated to GitHub Pages via GitHub Actions (.github/workflows/deploy.yml):
 
 - Triggers on pushes to `main` and daily at 08:25 UTC
-- Builds with `hugo --gc --minify` and `HUGO_ENV=production` (note: `task build` locally runs `hugo --minify` without `--gc` — minor drift, harmless but worth knowing)
+- Builds with `hugo --gc --minify --panicOnWarning` and `HUGO_ENV=production`; local `task build` and PR builds use the same strict flags.
 - Deploys via `actions/upload-pages-artifact` + `actions/deploy-pages` (artifact-based; no `gh-pages` branch)
 
 ## Notes

--- a/taskfile.yml
+++ b/taskfile.yml
@@ -44,7 +44,7 @@ tasks:
     generates:
       - public/**/*
     cmds:
-      - hugo --minify
+      - hugo --gc --minify --panicOnWarning
     env:
       HUGO_ENV: production
 


### PR DESCRIPTION
## Summary
- align PR/branch Hugo builds with deploy by adding `--gc --panicOnWarning`
- set `HUGO_ENV=production` for the PR/branch build
- update repo guidance to document the aligned strict build flags

Closes #716.

## Tests
- `task check`
- `task build`