### PR TITLE
Rewrite about.md around the site's own motto

### DIFF
--- a/content/about.md
+++ b/content/about.md
@@ -1,26 +1,18 @@
 ---
 title: About
 description: "A personal about page outlining the author's background, guiding principles, and philosophy on thinking, communication, and building. Draws on experiences spanning military service, nonprofits, and technology to frame a commitment to clarity and public thought."
-lastmod: 2026-04-06
+lastmod: 2026-07-02
 ---
 
 {{< latin-motto >}}
 
-This is where I think in public—sharing what I had to learn the hard way and saying what needs saying.
-
-I keep my rules simple: say yes and build, name things once, assume good intentions. Ask for permission only when it matters; keep tools and structure small; follow defaults until they fail; keep the signal sharp.
-
-I live in Rockford, Michigan, with my wife Kerry, in the Grand Rapids orbit. I run an independent development practice under the philoserf umbrella—mostly Go and TypeScript, with a deep AI-tooling habit—alongside regular shifts at Apple R132 Woodland. Family and friends shape the week as much as the work does, and that suits me.
-
 I am more synthesizer than specialist. My reading ranges freely—hickory-era golf, Whitehead, Gramsci, the philosophy of mind, parliamentary procedure, pilot-wave quantum mechanics—because I write to discover what I think, not to report what I already know. A draft usually opens with a strong sentence: I grant it its full force, then look for where it overreaches. Beneath this runs a rhythm of review, daily to yearly, carrying six threads—sleep, movement, diet, growth, play, and connection. Held to, the rhythm compounds; broken, it still teaches, provided I name the break plainly in the next review rather than let it pass.
 
-I've spent time in small towns, big cities, ancient ruins, busy shops, and server rooms, and shoveled snow, served burgers, worn a uniform, led teams, and worked alongside people building things that mattered to them.
+Most of what I know came from being on my feet, not at a desk. I've spent time in small towns, big cities, ancient ruins, busy shops, and server rooms. I've shoveled snow, served burgers, worn a uniform, led teams, and worked alongside people building things that mattered to them. Two stints in the Army (1980–1983, 1988–1992) taught me that clarity and discipline carry a team through chaos. Time in nonprofits showed me what a small group with a shared purpose can do. Companies of every size left me with the same lesson from different angles: the problems are hard, the time is short, and the people doing the work deserve better tools. What I carry from all of it: a sense of consequence and a habit of watching the edges.
 
-Two stints in the Army (1980–1983, 1988–1992) taught me that clarity and discipline carry a team through chaos. Time in nonprofits showed me what a small group with a shared purpose can do. Companies of every size, large and small, left me with the same lesson from different angles: the problems are hard, the time is short, and the people doing the work deserve better tools.
+None of that happens alone. I live in Rockford, Michigan, with my wife Kerry, in the Grand Rapids orbit. I run an independent development practice under the philoserf umbrella—mostly Go and TypeScript, with a deep AI-tooling habit—alongside regular shifts at Apple R132 Woodland. Family and friends shape the week as much as the work does, and that suits me. Away from the desk: I walk golf courses—hickory clubs when I can—and keep a public garden of notes on the game. Essays accumulate in draft. I build fiction in Traveller's Clement Sector and Distant Fringe settings, and code for fun—a letter-writing game called Quill, for one. I cook on a steady rotation. Coffee with friends, cocktails at home, a mug club at Rockford Brewing. The Giro, the Tour, and the Vuelta carry me through the cycling season, and camping and hiking take whatever the calendar leaves open.
 
-What I carry from all of it: a sense of consequence and a habit of watching the edges.
-
-Thought only becomes real when you put it into words others can use.
+This is where I think in public—sharing what I had to learn the hard way and saying what needs saying. I keep my rules simple: say yes and build; name things once; assume good intentions; ask for permission only when it matters; keep tools and structure small; follow defaults until they fail; keep the signal sharp. Thought only becomes real when I put it into words others can use.
 
 The easiest way to reach me: [mark@philoserf.com](mailto:mark@philoserf.com)
 


### PR DESCRIPTION
## Summary
- Restructures the About page as four movements through COGITA·DISCE·NECTE·ENUNTIA (think, learn, connect, declare) instead of a flat sequence of unrelated bio paragraphs
- Restores an interests/hobbies paragraph (golf, fiction, Quill, cooking, cycling, camping) that had been dropped entirely in #772 rather than fixed
- Moves "This is where I think in public" from the page opening to the declare movement, where it actually belongs thematically
- Fixes a few mechanical issues along the way: inconsistent list punctuation in the rules paragraph, a redundant "large and small", a stray second-person line in an otherwise first-person page, and an ungrammatical semicolon join from #772

## Test plan
- [x] `task check` (Hugo strict build with `--panicOnWarning`) passes
- [ ] Visual review of the rendered page