### PR TITLE
Load callout.css only on pages that use the callout shortcode

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -42,7 +42,7 @@
   {{ end }}
 
   <link rel="stylesheet" href="{{ "style.css" | relURL }}">
-  <link rel="stylesheet" href="{{ "callout.css" | relURL }}">
+  {{ if .HasShortcode "callout" }}<link rel="stylesheet" href="{{ "callout.css" | relURL }}">{{ end }}
   {{ partial "math.html" . }}
   {{ if .HasShortcode "mermaid" }}<script type="module" src="{{ "mermaid.js" | relURL }}"></script>{{ end }}
 


### PR DESCRIPTION
Gates the callout.css link behind `{{ if .HasShortcode "callout" }}`, exactly as mermaid.js is gated one line below. A clean production build confirms zero pages currently link it (no post uses the shortcode yet), and the file still ships in static/ for when one does.

Closes #771

https://claude.ai/code/session_01AWvS6yx1uRqbF1zGyXyQXp