### PR TITLE
Add dark-mode callout variants and rename --primary-dark by role

### DIFF
--- a/static/callout.css
+++ b/static/callout.css
@@ -85,3 +85,73 @@
   --callout-bg: #f5f5f5;
   --callout-accent: #757575;
 }
+
+@media (prefers-color-scheme: dark) {
+  .callout {
+    --callout-bg: var(--callout-note-bg, #1e2a3a);
+    --callout-accent: var(--callout-note-accent, #7ab3ec);
+  }
+  .callout-note {
+    --callout-bg: #1e2a3a;
+    --callout-accent: #7ab3ec;
+  }
+  .callout-abstract,
+  .callout-summary,
+  .callout-tldr {
+    --callout-bg: #1b2f2e;
+    --callout-accent: #4dc4b8;
+  }
+  .callout-info,
+  .callout-todo {
+    --callout-bg: #1c2b3a;
+    --callout-accent: #64b5f6;
+  }
+  .callout-tip,
+  .callout-hint,
+  .callout-important {
+    --callout-bg: #33291a;
+    --callout-accent: #ffb74d;
+  }
+  .callout-success,
+  .callout-check,
+  .callout-done {
+    --callout-bg: #1e2f20;
+    --callout-accent: #66bb6a;
+  }
+  .callout-question,
+  .callout-help,
+  .callout-faq {
+    --callout-bg: #2d2233;
+    --callout-accent: #ba68c8;
+  }
+  .callout-warning,
+  .callout-caution,
+  .callout-attention {
+    --callout-bg: #332718;
+    --callout-accent: #ffa040;
+  }
+  .callout-failure,
+  .callout-fail,
+  .callout-missing {
+    --callout-bg: #331f1f;
+    --callout-accent: #ef6e6b;
+  }
+  .callout-danger,
+  .callout-error {
+    --callout-bg: #331d1d;
+    --callout-accent: #e57373;
+  }
+  .callout-bug {
+    --callout-bg: #321f27;
+    --callout-accent: #ec5f8f;
+  }
+  .callout-example {
+    --callout-bg: #2b2133;
+    --callout-accent: #b077d6;
+  }
+  .callout-quote,
+  .callout-cite {
+    --callout-bg: #2a2620;
+    --callout-accent: #a89d8c;
+  }
+}

--- a/static/style.css
+++ b/static/style.css
@@ -1,7 +1,7 @@
 /* ============================================================
    philoserf — Warm Paper theme
-   Drop-in replacement for style.css. Same selectors and token
-   names as before; retinted + retyped for comfortable reading.
+   Retinted + retyped for comfortable reading; selectors match the
+   pre-redesign stylesheet.
    The header wordmark is rendered by baseof.html from .Site.Title.
    ============================================================ */
 
@@ -10,7 +10,9 @@
 :root {
   /* Color — warm paper */
   --primary-color: #0a66a8;
-  --primary-dark: #084e82;
+  /* Hover shifts away from the resting link color: darker on the light
+     scheme, brighter on the dark one — named by role, not lightness */
+  --link-hover: #084e82;
   --primary-light: #e9f1f8;
   --text-color: #241f18;
   --text-muted: #6d6353;
@@ -45,7 +47,7 @@
 @media (prefers-color-scheme: dark) {
   :root {
     --primary-color: #6aabdd;
-    --primary-dark: #93c4e8;
+    --link-hover: #93c4e8;
     --primary-light: #1e3346;
     --text-color: #e9e4da;
     --text-muted: #a89d8c;
@@ -169,7 +171,7 @@ a {
 }
 
 a:hover {
-  color: var(--primary-dark);
+  color: var(--link-hover);
 }
 
 /* --- Header & nav (centered wordmark over small-caps nav) --- */
@@ -503,7 +505,7 @@ article > header time {
 .pagination a:hover,
 .pagination a:focus {
   border-color: var(--primary-color);
-  color: var(--primary-dark);
+  color: var(--link-hover);
 }
 
 /* --- Homepage --- */


### PR DESCRIPTION
## Summary

Grouped fix for the two dark-mode color issues:

**#769 — callout dark variants.** `static/callout.css` is synced from the upstream reference in philoserf/obsidian-publisher#238, which adds a `prefers-color-scheme: dark` override for every callout type: deep desaturated backgrounds, brightened accents, tuned to sit on the warm dark ground (`#201d18`/`#2a2620`). No post uses callouts yet (and since #775 the stylesheet only loads on pages that do), so nothing visible changes today.

**#770 — `--primary-dark` naming.** The report was correct: in dark mode the token held a *lighter* value than `--primary-color`, on purpose (hover brightens against a dark ground), so the name misdescribed the value and invited a future "fix" that would break hover contrast. Rather than renaming it to another lightness word or just commenting, the token is now named by role: `--link-hover`, defined per scheme, consumed by `a:hover` and `.pagination a:hover/:focus`. **Values are unchanged in both schemes** — no visual change.

The stylesheet header's "same token names as before" claim is updated accordingly.

Closes #769
Closes #770

## Test plan

- `task check` (strict build) passes
- `grep primary-dark static/*.css` → no remaining references
- Callout dark palette reviewed against the Warm Paper dark tokens

https://claude.ai/code/session_01AWvS6yx1uRqbF1zGyXyQXp