### PR TITLE
Add Automobile section to uses page

### DIFF
--- a/content/uses.md
+++ b/content/uses.md
@@ -2,7 +2,7 @@
 title: Uses
 eyebrow: "What I use"
 description: "What I use day to day for writing, coding, and publishing. Updated when reality changes."
-lastmod: 2026-07-03
+lastmod: 2026-07-21
 ---
 
 What I use day to day. Updated when reality changes — not aspirations, not everything I've tried.
@@ -27,6 +27,12 @@ What I use day to day. Updated when reality changes — not aspirations, not eve
 
 - Modern: Ping G2 5-wood, Ping S59 irons, Takomo wedges, Ping Craz-E putter, Callaway balls, Ping Hoofer Lite bag
 - Hickory: Tad Moore 8-club set, MacIntyre balls, Tuberon canvas bag
+
+## Automobile
+
+- Vehicle: 2005 Honda Element
+- Camper: Fifth Element micro-camper kit
+- Phone mount: Peak Design
 
 ---
 


### PR DESCRIPTION
Adds an **Automobile** section to `/uses/`: 2005 Honda Element, Fifth Element micro-camper kit, and a Peak Design phone mount. Bumps `lastmod`.

https://claude.ai/code/session_01LdBYjRUJymzGezRksJXCqk