### PR TITLE
Feature two posts on the homepage front grid

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -17,7 +17,8 @@ params:
     headline: "Uncompressed public thinking"
     startHereIntro: "Essays that say what the rest is trying to do."
     featured:
-      pageRef: /posts/agency-without-a-self
+      - pageRef: /posts/agency-without-a-self
+      - pageRef: /posts/elasticity-of-moral-circles
     startHere:
       - pageRef: /posts/two-epistemic-cycles
       - pageRef: /posts/uncompressed-public-thinking

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -9,18 +9,21 @@
 {{ define "main" }}
 {{ $posts := where .Site.RegularPages "Section" "posts" }}
 {{ $posts = $posts.ByDate.Reverse }}
-{{ $featuredConfig := .Site.Params.home.featured }}
-{{ $featured := false }}
-{{ $note := "" }}
-{{ with $featuredConfig }}
-  {{ $featured = $.Site.GetPage .pageRef }}
-  {{ if not $featured }}{{ errorf "homepage featured page not found: %s" .pageRef }}{{ end }}
-  {{ $note = .note }}
+{{ $featured := slice }}
+{{ with .Site.Params.home.featured }}
+  {{ range . }}
+    {{ $page := $.Site.GetPage .pageRef }}
+    {{ if not $page }}{{ errorf "homepage featured page not found: %s" .pageRef }}{{ end }}
+    {{ $featured = $featured | append (dict "page" $page "note" (.note | default $page.Description)) }}
+  {{ end }}
 {{ else }}
-  {{ $featured = index $posts 0 }}
+  {{ range first 1 $posts }}
+    {{ $featured = $featured | append (dict "page" . "note" .Description) }}
+  {{ end }}
 {{ end }}
-{{ $note = $note | default $featured.Description }}
-{{ $recent := where $posts "RelPermalink" "ne" $featured.RelPermalink | first 4 }}
+{{ $featuredLinks := slice }}
+{{ range $featured }}{{ $featuredLinks = $featuredLinks | append .page.RelPermalink }}{{ end }}
+{{ $recent := where $posts "RelPermalink" "not in" $featuredLinks | first 4 }}
 
 <main id="main" class="home-main">
   <section class="hero">
@@ -33,12 +36,16 @@
   </section>
 
   <section class="front-grid" aria-label="Featured and recent posts">
-    <article class="featured">
-      <p class="eyebrow">Featured post</p>
-      <h2><a href="{{ $featured.RelPermalink }}">{{ $featured.Title }}</a></h2>
-      <p>{{ $note }}</p>
-      <div class="meta"><time datetime="{{ $featured.Date.Format "2006-01-02" }}">{{ $featured.Date.Format "January 2, 2006" }}</time><span>Post</span></div>
-    </article>
+    <div class="featured-stack">
+      {{ range $featured }}
+      <article class="featured">
+        <p class="eyebrow">Featured post</p>
+        <h2><a href="{{ .page.RelPermalink }}">{{ .page.Title }}</a></h2>
+        <p>{{ .note }}</p>
+        <div class="meta"><time datetime="{{ .page.Date.Format "2006-01-02" }}">{{ .page.Date.Format "January 2, 2006" }}</time><span>Post</span></div>
+      </article>
+      {{ end }}
+    </div>
     <div class="recent">
       <div class="section-heading"><h2>Recent</h2><a href="{{ "/posts/" | relURL }}">All posts</a></div>
       {{ range $recent }}

--- a/static/style.css
+++ b/static/style.css
@@ -595,11 +595,29 @@ body > header {
   border-top: 1px solid var(--border-color);
 }
 
-.featured {
+.featured-stack {
+  display: grid;
+  gap: 2rem;
   align-self: start;
+}
+
+.featured-stack .featured {
+  margin-bottom: 0; /* cancel the single-post article margin, which doubles the stack gap */
+}
+
+.featured {
   padding: 2.6rem;
   background: var(--surface-color);
   border-top: 4px solid var(--text-color);
+}
+
+.featured-stack .featured:nth-child(n + 2) {
+  border-top-width: 1px;
+  border-top-color: var(--border-color);
+}
+
+.featured-stack .featured:nth-child(n + 2) h2 {
+  font-size: clamp(1.5rem, 3vw, 2rem);
 }
 
 .featured h2 {


### PR DESCRIPTION
The featured column left ~340px of empty space beside the four-row Recent list at every two-column width (tablet and desktop). This fills it with a second featured card.

## Changes

- **hugo.yaml** — `home.featured` is now a list of `pageRef` entries (each still accepts an optional `note` override). Adds `/posts/elasticity-of-moral-circles` as the second featured post, complementing the thinking/identity pillar of the first with the civilization pillar.
- **layouts/index.html** — resolves the featured list with the same `errorf` guard and `note → .Description` fallback per entry, renders the cards in a `.featured-stack` wrapper, and excludes every featured permalink from Recent so the list stays at four with no duplicates. With no config it falls back to featuring the newest post, as before.
- **static/style.css** — the stack carries `align-self: start` with a 2rem gap; cards after the first get a 1px border and smaller title so the first post keeps top billing. Also cancels the single-post `article` bottom margin inside the stack, which was doubling the gap. No breakpoint changes: below 760px both cards stack above Recent in the existing single column.

## Verification

- Strict production build passes (`hugo --gc --minify --panicOnWarning`, same flags as deploy).
- Headless-browser measurements at 390/810/1280px: the two columns balance to exactly 651px each at 1280px, within 13px at 810px, and stack cleanly on mobile.
- Prettier check passes on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JXpBwijFj2HPtB4dWTGcKj

---
_Generated by [Claude Code](https://claude.ai/code/session_01JXpBwijFj2HPtB4dWTGcKj)_